### PR TITLE
Use new wait for status endpoint in await_running

### DIFF
--- a/src/runloop_api_client/resources/devboxes/devboxes.py
+++ b/src/runloop_api_client/resources/devboxes/devboxes.py
@@ -103,12 +103,12 @@ from ...lib.polling_async import async_poll_until
 from ...types.devbox_view import DevboxView
 from ...types.devbox_tunnel_view import DevboxTunnelView
 from ...types.devbox_snapshot_view import DevboxSnapshotView
+from ...types.shared.launch_parameters import LaunchParameters as SharedLaunchParameters
 from ...types.devbox_execution_detail_view import DevboxExecutionDetailView
 from ...types.devbox_create_ssh_key_response import DevboxCreateSSHKeyResponse
 from ...types.shared_params.launch_parameters import LaunchParameters
 from ...types.devbox_async_execution_detail_view import DevboxAsyncExecutionDetailView
 from ...types.shared_params.code_mount_parameters import CodeMountParameters
-from ...types.shared.launch_parameters import LaunchParameters as SharedLaunchParameters
 
 __all__ = ["DevboxesResource", "AsyncDevboxesResource"]
 

--- a/src/runloop_api_client/resources/devboxes/executions.py
+++ b/src/runloop_api_client/resources/devboxes/executions.py
@@ -16,8 +16,8 @@ from ..._response import (
     async_to_raw_response_wrapper,
     async_to_streamed_response_wrapper,
 )
-from ...lib.polling import PollingConfig, poll_until
 from ..._constants import DEFAULT_TIMEOUT
+from ...lib.polling import PollingConfig, poll_until
 from ..._base_client import make_request_options
 from ...types.devboxes import execution_retrieve_params, execution_execute_sync_params, execution_execute_async_params
 from ...lib.polling_async import async_poll_until
@@ -103,7 +103,6 @@ class ExecutionsResource(SyncAPIResource):
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
-        idempotency_key: str | None = None,
     ) -> DevboxAsyncExecutionDetailView:
         """Wait for an execution to complete.
         
@@ -380,7 +379,6 @@ class AsyncExecutionsResource(AsyncAPIResource):
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
-        idempotency_key: str | None = None,
     ) -> DevboxAsyncExecutionDetailView:
         """Wait for an execution to complete.
         
@@ -406,7 +404,7 @@ class AsyncExecutionsResource(AsyncAPIResource):
                 extra_headers=extra_headers,
                 extra_query=extra_query,
                 extra_body=extra_body,
-                timeout=timeout
+                timeout=timeout,
             )
 
         def is_done(execution: DevboxAsyncExecutionDetailView) -> bool:


### PR DESCRIPTION
Similar to https://github.com/runloopai/api-client-ts/pull/590, use long polling API method in `await_running`. 

Instead of making a bunch of retrieve devbox calls, we use a single `wait_for_status` call. If it timesout, retry. It will finish when the devbox reaches `running` or `failure` state.