### PR TITLE
Add worker for smoketest github action

### DIFF
--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -49,7 +49,8 @@ jobs:
 
       - name: Run smoke tests (pytest via uv)
         env:
-          # Force sequential to avoid overloading remote resources
-          PYTEST_ADDOPTS: "-n 1 -m smoketest"
+          # Use 2 workers to run files in parallel.
+          # Tests within a file are run sequentially.
+          PYTEST_ADDOPTS: "-n 2 -m smoketest"
         run: |
           uv run pytest -q -vv tests/smoketests


### PR DESCRIPTION
Adds another worker for the github action. Test duration went from 5 min -> 3 min. Maybe can bump up in the future, but default runner for github actions only has 2 vCPU