### PR TITLE
fix: update test script to work without lsof on CI

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -13,6 +13,28 @@ function steady_is_running() {
   curl --silent "http://127.0.0.1:4010/_x-steady/health" >/dev/null 2>&1
 }
 
+find_pids_on_port_via_proc() {
+  # Parse /proc/net/tcp{,6} to find socket inodes listening on the port,
+  # then scan /proc/*/fd/ to find which pids own those sockets.
+  local port_hex
+  port_hex=$(printf '%04X' "$1")
+  local inodes
+  inodes=$(awk -v ph="$port_hex" '$2 ~ ":"ph"$" && $4 == "0A" {print $10}' /proc/net/tcp /proc/net/tcp6 2>/dev/null | sort -u)
+  [ -z "$inodes" ] && return
+  local pids=""
+  for inode in $inodes; do
+    for fd in /proc/[0-9]*/fd/*; do
+      if [ "$(readlink "$fd" 2>/dev/null)" = "socket:[$inode]" ]; then
+        local pid="${fd#/proc/}"
+        pid="${pid%%/fd/*}"
+        pids="$pids $pid"
+        break
+      fi
+    done
+  done
+  echo "$pids" | xargs
+}
+
 kill_server_on_port() {
   if command -v lsof >/dev/null 2>&1; then
     pids=$(lsof -t -i tcp:"$1" || echo "")
@@ -20,6 +42,8 @@ kill_server_on_port() {
     pids=$(ss -tlnp "sport = :$1" 2>/dev/null | grep -oP 'pid=\K[0-9]+' || echo "")
   elif command -v fuser >/dev/null 2>&1; then
     pids=$(fuser "$1/tcp" 2>/dev/null || echo "")
+  elif [ -d /proc/net ]; then
+    pids=$(find_pids_on_port_via_proc "$1")
   else
     echo "Warning: no tool available to find processes on port $1"
     return

--- a/scripts/test
+++ b/scripts/test
@@ -14,9 +14,18 @@ function steady_is_running() {
 }
 
 kill_server_on_port() {
-  pids=$(lsof -t -i tcp:"$1" || echo "")
+  if command -v lsof >/dev/null 2>&1; then
+    pids=$(lsof -t -i tcp:"$1" || echo "")
+  elif command -v ss >/dev/null 2>&1; then
+    pids=$(ss -tlnp "sport = :$1" 2>/dev/null | grep -oP 'pid=\K[0-9]+' || echo "")
+  elif command -v fuser >/dev/null 2>&1; then
+    pids=$(fuser "$1/tcp" 2>/dev/null || echo "")
+  else
+    echo "Warning: no tool available to find processes on port $1"
+    return
+  fi
   if [ "$pids" != "" ]; then
-    kill "$pids"
+    kill $pids
     echo "Stopped $pids."
   fi
 }


### PR DESCRIPTION
## Summary
We had one test which worked locally but failed reliably in the github CI environment due to lsof not being installed.  This fix should get the CI tests back to green.

- Add fallbacks for `kill_server_on_port` when `lsof` is unavailable (e.g. on GitHub Actions runners)
- Try `ss`, then `fuser`, then parse `/proc/net/tcp` directly as a final fallback
- Warn gracefully if no method is available

## Test plan
- [ ] Verify CI passes on GitHub Actions (Linux runners without `lsof`)
- [ ] Verify local `./scripts/test` still works on macOS (uses `lsof` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)