### PR TITLE
Fix async test client cleanup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import asyncio
 import logging
 from typing import TYPE_CHECKING, Iterator, AsyncIterator
 
@@ -108,6 +109,14 @@ async def async_client(request: FixtureRequest) -> AsyncIterator[AsyncRunloop]:
         raise TypeError(f"Unexpected fixture parameter type {type(param)}, expected bool or dict")
 
     async with AsyncRunloop(
-        base_url=base_url, bearer_token=bearer_token, _strict_response_validation=strict, http_client=http_client
+        base_url=base_url,
+        bearer_token=bearer_token,
+        _strict_response_validation=strict,
+        http_client=http_client,
+        shared_http_pool=False,
     ) as client:
         yield client
+
+    # Give async transports a chance to finish closing before pytest collects
+    # unraisable ResourceWarnings under filterwarnings=error.
+    await asyncio.sleep(0.1)


### PR DESCRIPTION
## Summary
- keep the shared async test fixture off the SDK global connection pool so parametrized/xdist resource tests do not leak pooled sockets into later tests
- yield the event loop after closing async test clients so transports can finish cleanup
- prevents delayed ResourceWarning/PytestUnraisableExceptionWarning failures under warnings-as-errors in CI

## Verification
- env UV_PYTHON='>=3.9.0' ./scripts/test tests/api_resources/test_agents.py tests/sdk/test_async_scenario_builder.py -q
- env UV_PYTHON='>=3.9.0' ./scripts/test -q
- uv run ruff check tests/conftest.py
- uv run ruff format --check tests/conftest.py

Note: ./scripts/lint currently fails before reaching touched code due missing docs Sphinx imports in pyright.