### PR TITLE
fix: revert workflow actions to runloopai forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ github.repository == 'stainless-sdks/runloop-python' && 'depot-ubuntu-24.04' || 'ubuntu-slim' }}
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
     steps:
-      - uses: actions/checkout@v6
+      - uses: runloopai/checkout@main
 
       - name: Install uv
         uses: runloopai/setup-uv@main
@@ -46,7 +46,7 @@ jobs:
       id-token: write
     runs-on: ${{ github.repository == 'stainless-sdks/runloop-python' && 'depot-ubuntu-24.04' || 'ubuntu-slim' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: runloopai/checkout@main
 
       - name: Install uv
         uses: runloopai/setup-uv@main
@@ -84,7 +84,7 @@ jobs:
     runs-on: ${{ github.repository == 'stainless-sdks/runloop-python' && 'depot-ubuntu-24.04' || 'ubuntu-slim' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     steps:
-      - uses: actions/checkout@v6
+      - uses: runloopai/checkout@main
 
       - name: Install uv
         uses: runloopai/setup-uv@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           github.repository == 'stainless-sdks/runloop-python' &&
           !startsWith(github.ref, 'refs/heads/stl/')
         id: github-oidc
-        uses: actions/github-script@v8
+        uses: runloopai/github-script@main
         with:
           script: core.setOutput('github_token', await core.getIDToken());
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-slim
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: runloopai/checkout@main
 
       - name: Install uv
         uses: runloopai/setup-uv@main

--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'runloopai/api-client-python' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please') || github.head_ref == 'next')
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: runloopai/checkout@main
 
       - name: Check release environment
         run: |


### PR DESCRIPTION
## Summary
- Reverts `actions/checkout@v6` → `runloopai/checkout@main` in `ci.yml`, `publish-pypi.yml`, and `release-doctor.yml`
- Reverts `actions/github-script@v8` → `runloopai/github-script@main` in `ci.yml`
- These were accidentally changed in commit 80c9f2b

## Test plan
- [ ] CI workflows run successfully with runloopai action forks

🤖 Generated with [Claude Code](https://claude.com/claude-code)