### PR TITLE
feat(devbox): add provisioning_tier (flex) to LaunchParameters (alpha)

### DIFF
--- a/src/runloop_api_client/types/shared/launch_parameters.py
+++ b/src/runloop_api_client/types/shared/launch_parameters.py
@@ -75,7 +75,7 @@ class LaunchParameters(BaseModel):
     """
 
     provisioning_tier: Optional[Literal["standard", "flex"]] = None
-    """(Alpha) standard is default and flex is lazily provisioned and may be pre-empted.
+    """(Optional, Alpha) standard is default and flex is lazily provisioned and may be pre-empted.
 
     This is an alpha feature and its behavior may change without notice.
     """

--- a/src/runloop_api_client/types/shared/launch_parameters.py
+++ b/src/runloop_api_client/types/shared/launch_parameters.py
@@ -74,6 +74,9 @@ class LaunchParameters(BaseModel):
     will inherit this policy unless explicitly overridden.
     """
 
+    provisioning_tier: Optional[Literal["standard", "flex"]] = None
+    """(Optional) standard is default and flex is lazily provisioned and may be pre-empted."""
+
     required_services: Optional[List[str]] = None
     """A list of ContainerizedService names to be started when a Devbox is created.
 

--- a/src/runloop_api_client/types/shared/launch_parameters.py
+++ b/src/runloop_api_client/types/shared/launch_parameters.py
@@ -75,7 +75,10 @@ class LaunchParameters(BaseModel):
     """
 
     provisioning_tier: Optional[Literal["standard", "flex"]] = None
-    """(Optional) standard is default and flex is lazily provisioned and may be pre-empted."""
+    """(Alpha) standard is default and flex is lazily provisioned and may be pre-empted.
+
+    This is an alpha feature and its behavior may change without notice.
+    """
 
     required_services: Optional[List[str]] = None
     """A list of ContainerizedService names to be started when a Devbox is created.

--- a/src/runloop_api_client/types/shared_params/launch_parameters.py
+++ b/src/runloop_api_client/types/shared_params/launch_parameters.py
@@ -77,7 +77,7 @@ class LaunchParameters(TypedDict, total=False):
     """
 
     provisioning_tier: Optional[Literal["standard", "flex"]]
-    """(Alpha) standard is default and flex is lazily provisioned and may be pre-empted.
+    """(Optional, Alpha) standard is default and flex is lazily provisioned and may be pre-empted.
 
     This is an alpha feature and its behavior may change without notice.
     """

--- a/src/runloop_api_client/types/shared_params/launch_parameters.py
+++ b/src/runloop_api_client/types/shared_params/launch_parameters.py
@@ -76,6 +76,9 @@ class LaunchParameters(TypedDict, total=False):
     will inherit this policy unless explicitly overridden.
     """
 
+    provisioning_tier: Optional[Literal["standard", "flex"]]
+    """(Optional) standard is default and flex is lazily provisioned and may be pre-empted."""
+
     required_services: Optional[SequenceNotStr[str]]
     """A list of ContainerizedService names to be started when a Devbox is created.
 

--- a/src/runloop_api_client/types/shared_params/launch_parameters.py
+++ b/src/runloop_api_client/types/shared_params/launch_parameters.py
@@ -77,7 +77,10 @@ class LaunchParameters(TypedDict, total=False):
     """
 
     provisioning_tier: Optional[Literal["standard", "flex"]]
-    """(Optional) standard is default and flex is lazily provisioned and may be pre-empted."""
+    """(Alpha) standard is default and flex is lazily provisioned and may be pre-empted.
+
+    This is an alpha feature and its behavior may change without notice.
+    """
 
     required_services: Optional[SequenceNotStr[str]]
     """A list of ContainerizedService names to be started when a Devbox is created.


### PR DESCRIPTION
### Description

Adds the optional `provisioning_tier` field (`"standard" | "flex"`) to `LaunchParameters`, in both the request params model (`types/shared_params/launch_parameters.py`) and the response model (`types/shared/launch_parameters.py`), matching the `architecture` enum pattern.

This corresponds to the field now exposed in the OpenAPI spec (see runloopai/runloop). It is **hand-applied ahead of the next Stainless regeneration** so the alpha customer can use the field immediately; a subsequent Stainless run will converge to the same shape.

> Alpha soft-launch: `provisioning_tier` is intentionally **kept out of the public docs** — the field is stripped from the documented spec before it is pushed to the docs site (handled upstream in runloopai/runloop). It is present here in the SDK on purpose.

### Motivation

Soft-launch `provisioning_tier=flex` as an alpha for a single customer: usable via the SDK, absent from public docs.

### Testing

- Field added in alphabetical position (between `network_policy_id` and `required_services`) matching the generator's ordering; `Literal` already imported in both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)