### PR TITLE
feat(sdk): add streaming download_to_file for devbox files

### DIFF
--- a/src/runloop_api_client/sdk/async_devbox.py
+++ b/src/runloop_api_client/sdk/async_devbox.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import asyncio
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Awaitable, cast
@@ -660,6 +661,31 @@ class AsyncFileInterface:
             **params,
         )
         return await response.read()
+
+    async def download_to_file(
+        self,
+        dest: str | os.PathLike[str],
+        *,
+        chunk_size: int | None = None,
+        **params: Unpack[SDKDevboxDownloadFileParams],
+    ) -> None:
+        """Download a file from the devbox, streaming it directly to ``dest``.
+
+        Unlike :meth:`download`, this never holds the whole file in memory: the
+        response body is streamed to disk in chunks, so it is safe for large files.
+
+        :param dest: Local path to write the downloaded contents to.
+        :param chunk_size: Size in bytes of each streamed chunk (httpx default if None).
+        :param params: See :typeddict:`~runloop_api_client.sdk._types.SDKDevboxDownloadFileParams` for available parameters
+
+        Example:
+            >>> await devbox.file.download_to_file("local_output.bin", path="/home/user/output.bin")
+        """
+        async with self._devbox._client.devboxes.with_streaming_response.download_file(
+            self._devbox.id,
+            **params,
+        ) as response:
+            await response.stream_to_file(dest, chunk_size=chunk_size)
 
     async def upload(
         self,

--- a/src/runloop_api_client/sdk/devbox.py
+++ b/src/runloop_api_client/sdk/devbox.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import logging
 import threading
 from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence
@@ -663,6 +664,31 @@ class FileInterface:
             **params,
         )
         return response.read()
+
+    def download_to_file(
+        self,
+        dest: str | os.PathLike[str],
+        *,
+        chunk_size: int | None = None,
+        **params: Unpack[SDKDevboxDownloadFileParams],
+    ) -> None:
+        """Download a file from the devbox, streaming it directly to ``dest``.
+
+        Unlike :meth:`download`, this never holds the whole file in memory: the
+        response body is streamed to disk in chunks, so it is safe for large files.
+
+        :param dest: Local path to write the downloaded contents to.
+        :param chunk_size: Size in bytes of each streamed chunk (httpx default if None).
+        :param params: See :typeddict:`~runloop_api_client.sdk._types.SDKDevboxDownloadFileParams` for available parameters
+
+        Example:
+            >>> devbox.file.download_to_file("local_output.bin", path="/home/user/output.bin")
+        """
+        with self._devbox._client.devboxes.with_streaming_response.download_file(
+            self._devbox.id,
+            **params,
+        ) as response:
+            response.stream_to_file(dest, chunk_size=chunk_size)
 
     def upload(
         self,

--- a/tests/sdk/async_devbox/test_interfaces.py
+++ b/tests/sdk/async_devbox/test_interfaces.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import Mock, AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -139,6 +139,30 @@ class TestAsyncFileInterface:
 
         assert result == b"file content"
         mock_async_client.devboxes.download_file.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_download_to_file(self, mock_async_client: AsyncMock, tmp_path: Path) -> None:
+        """Test streaming file download writes to disk without buffering."""
+        dest = tmp_path / "out.bin"
+
+        def _stream(path: object, *args: object, **kwargs: object) -> None:  # noqa: ARG001
+            with open(path, "wb") as f:  # type: ignore[arg-type]
+                f.write(b"streamed content")
+
+        mock_response = Mock()
+        mock_response.stream_to_file = AsyncMock(side_effect=_stream)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=mock_response)
+        cm.__aexit__ = AsyncMock(return_value=None)
+        mock_async_client.devboxes.with_streaming_response.download_file = Mock(return_value=cm)
+
+        devbox = AsyncDevbox(mock_async_client, "dbx_123")
+        await devbox.file.download_to_file(dest, path="/path/to/file")
+
+        assert dest.read_bytes() == b"streamed content"
+        mock_response.stream_to_file.assert_awaited_once()
+        call_kwargs = mock_async_client.devboxes.with_streaming_response.download_file.call_args[1]
+        assert call_kwargs["path"] == "/path/to/file"
 
     @pytest.mark.asyncio
     async def test_upload(self, mock_async_client: AsyncMock, tmp_path: Path) -> None:

--- a/tests/sdk/devbox/test_interfaces.py
+++ b/tests/sdk/devbox/test_interfaces.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, MagicMock
 
 import httpx
 
@@ -232,6 +232,28 @@ class TestFileInterface:
         call_kwargs = mock_client.devboxes.download_file.call_args[1]
         assert call_kwargs["path"] == "/path/to/file"
         assert "timeout" not in call_kwargs
+
+    def test_download_to_file(self, mock_client: Mock, tmp_path: Path) -> None:
+        """Test streaming file download writes to disk without buffering."""
+        dest = tmp_path / "out.bin"
+
+        def _stream(path: object, *args: object, **kwargs: object) -> None:  # noqa: ARG001
+            with open(path, "wb") as f:  # type: ignore[arg-type]
+                f.write(b"streamed content")
+
+        mock_response = Mock()
+        mock_response.stream_to_file.side_effect = _stream
+        cm = MagicMock()
+        cm.__enter__.return_value = mock_response
+        mock_client.devboxes.with_streaming_response.download_file.return_value = cm
+
+        devbox = Devbox(mock_client, "dbx_123")
+        devbox.file.download_to_file(dest, path="/path/to/file")
+
+        assert dest.read_bytes() == b"streamed content"
+        mock_response.stream_to_file.assert_called_once()
+        call_kwargs = mock_client.devboxes.with_streaming_response.download_file.call_args[1]
+        assert call_kwargs["path"] == "/path/to/file"
 
     def test_upload(self, mock_client: Mock, tmp_path: Path) -> None:
         """Test file upload."""


### PR DESCRIPTION
## Summary

`devbox.file.download()` reads the **entire file into memory** (`response.read()`), the mirror image of the upload-side buffering. This adds `download_to_file(dest)` on both the sync and async `FileInterface` that streams the response body straight to disk in chunks via `with_streaming_response`, so large downloads never have to fit in RAM.

The existing `download()` (returns `bytes`) is kept unchanged for small-file convenience — streaming into a `bytes` return is impossible by definition, so this is additive rather than a behavior change.

Companion to #815 (streaming uploads).

## Changes

- `sdk/devbox.py` / `sdk/async_devbox.py`: new `download_to_file(dest, *, chunk_size=None, **params)` using `with_streaming_response.download_file(...)` + `stream_to_file`.
- Tests: `test_download_to_file` (sync + async) assert the body is streamed to disk and the correct `path` is forwarded.

## Usage

```python
devbox.file.download_to_file("local_output.bin", path="/home/user/output.bin")
# async:
await devbox.file.download_to_file("local_output.bin", path="/home/user/output.bin")
```

## Test plan

- [x] `uv run pytest tests/sdk/devbox tests/sdk/async_devbox` — 95 passed
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)