### PR TITLE
fix: retry polling on HTTP/2 GOAWAY connection errors

### DIFF
--- a/src/runloop_api_client/lib/wait_for_status.py
+++ b/src/runloop_api_client/lib/wait_for_status.py
@@ -14,7 +14,7 @@ import time
 from typing import List, Type, TypeVar, Callable, Optional, Awaitable
 
 from .polling import PollingConfig, PollingTimeout
-from .._exceptions import APIStatusError, APITimeoutError
+from .._exceptions import APIStatusError, APIConnectionError
 
 T = TypeVar("T")
 
@@ -49,8 +49,8 @@ def wait_for_status(
                 cast_to=cast_to,
                 options={"max_retries": 0},
             )
-        except (APITimeoutError, APIStatusError) as error:
-            if isinstance(error, APITimeoutError) or error.response.status_code == 408:
+        except (APIConnectionError, APIStatusError) as error:
+            if isinstance(error, APIConnectionError) or error.response.status_code == 408:
                 last_result = placeholder()
             else:
                 raise
@@ -89,8 +89,8 @@ async def async_wait_for_status(
                 cast_to=cast_to,
                 options={"max_retries": 0},
             )
-        except (APITimeoutError, APIStatusError) as error:
-            if isinstance(error, APITimeoutError) or error.response.status_code == 408:
+        except (APIConnectionError, APIStatusError) as error:
+            if isinstance(error, APIConnectionError) or error.response.status_code == 408:
                 last_result = placeholder()
             else:
                 raise

--- a/src/runloop_api_client/resources/devboxes/devboxes.py
+++ b/src/runloop_api_client/resources/devboxes/devboxes.py
@@ -71,7 +71,7 @@ from ...pagination import (
     SyncDiskSnapshotsCursorIDPage,
     AsyncDiskSnapshotsCursorIDPage,
 )
-from ..._exceptions import RunloopError, APIStatusError, APITimeoutError
+from ..._exceptions import RunloopError, APIStatusError, APIConnectionError
 from ...lib.polling import PollingConfig, poll_until
 from ..._base_client import AsyncPaginator, make_request_options
 from .disk_snapshots import (
@@ -957,7 +957,7 @@ class DevboxesResource(SyncAPIResource):
             return execution
 
         def handle_timeout_error(error: Exception) -> DevboxAsyncExecutionDetailView:
-            if isinstance(error, APITimeoutError) or (
+            if isinstance(error, APIConnectionError) or (
                 isinstance(error, APIStatusError) and error.response.status_code == 408
             ):
                 return execution
@@ -2627,7 +2627,7 @@ class AsyncDevboxesResource(AsyncAPIResource):
             return execution
 
         def handle_timeout_error(error: Exception) -> DevboxAsyncExecutionDetailView:
-            if isinstance(error, APITimeoutError) or (
+            if isinstance(error, APIConnectionError) or (
                 isinstance(error, APIStatusError) and error.response.status_code == 408
             ):
                 return execution


### PR DESCRIPTION
APITimeoutError is a subclass of APIConnectionError, so the previous except clauses caught timeouts but not bare APIConnectionError, which is what httpx raises when an HTTP/2 GOAWAY frame drops the connection mid-poll. Catch APIConnectionError instead so GOAWAY-interrupted polls continue retrying rather than surfacing as APIConnectionError to callers.